### PR TITLE
Fix timeout wrapper context usage

### DIFF
--- a/backfed/utils/misc_utils.py
+++ b/backfed/utils/misc_utils.py
@@ -8,6 +8,7 @@ import torch
 
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Optional, Dict
+from contextlib import nullcontext
 
 # Method 1: Convert async to sync function
 def async_to_sync(func: Callable) -> Callable:
@@ -49,7 +50,7 @@ def with_timeout(func: Callable, timeout: Optional[float] = None) -> Callable:
     
     async def timeout_wrapper(*args, **kwargs) -> Dict:
         try:
-            async with asyncio.timeout(timeout) if timeout else asyncio.nullcontext():
+            async with asyncio.timeout(timeout) if timeout else nullcontext():
                 return await async_func(*args, **kwargs)
         except asyncio.TimeoutError:
             # Assuming first arg is self for class methods


### PR DESCRIPTION
## Summary
- fix with_timeout so it uses contextlib.nullcontext when no timeout is given

## Testing
- `python -m compileall -q .`
- `python - <<'PY'
import importlib.util, asyncio
spec = importlib.util.spec_from_file_location('misc_utils','backfed/utils/misc_utils.py')
mu = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mu)
async def sample():
    return 'done'
async def main():
    wrapped = mu.with_timeout(sample, None)
    result = await wrapped()
    print(result)
asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a4b801a8988322b7a327e0035f678f